### PR TITLE
Same token same color

### DIFF
--- a/src/sections/TokenViewer.tsx
+++ b/src/sections/TokenViewer.tsx
@@ -63,6 +63,18 @@ export function TokenViewer(props: {
 
   const [showWhitespace, setShowWhitespace] = useState(false);
 
+  // Keep track of the first occurrence of each token
+  const firstOccurrences: Record<number, number> = {};
+  props.data?.forEach(({ tokens }) => {
+    tokens.forEach(({ id, idx }) => {
+      if (firstOccurrences[id] == null) {
+        firstOccurrences[id] = idx;
+      }
+    });
+  });
+
+  console.log(props.data)
+
   return (
     <>
       <div className="flex gap-4">
@@ -75,83 +87,83 @@ export function TokenViewer(props: {
           <div className="flex-grow rounded-md border bg-slate-50 p-4 shadow-sm">
             <p className="text-sm ">Price per prompt</p>
             <p className="text-lg">
-              ${pricing?.multipliedBy(tokenCount)?.toFixed()}
-            </p>
-          </div>
-        )}
+              ${pricing?.multipliedBy(tokenCount)?.        toFixed()}
+        </p>
       </div>
+    )}
+  </div>
 
-      <pre className="min-h-[256px] max-w-[100vw] overflow-auto whitespace-pre-wrap break-all rounded-md border bg-slate-50 p-4 shadow-sm">
-        {props.data?.map(({ text }, idx) => (
-          <span
-            key={idx}
-            onMouseEnter={() => setIndexHover(idx)}
-            onMouseLeave={() => setIndexHover(null)}
-            className={cn(
-              "transition-all",
-              (indexHover == null || indexHover === idx) &&
-                COLORS[idx % COLORS.length],
-              props.isFetching && "opacity-50"
-            )}
-          >
-            {showWhitespace || indexHover === idx
-              ? encodeWhitespace(text)
-              : text}
-          </span>
-        ))}
-      </pre>
-
-      <pre
-        className={
-          "min-h-[256px] max-w-[100vw] overflow-auto whitespace-pre-wrap break-all rounded-md border bg-slate-50 p-4 shadow-sm"
-        }
+  <pre className="min-h-[256px] max-w-[100vw] overflow-auto whitespace-pre-wrap break-all rounded-md border bg-slate-50 p-4 shadow-sm">
+    {props.data?.map(({ text, tokens }, idx) => (
+      <span
+        key={idx}
+        onMouseEnter={() => setIndexHover(idx)}
+        onMouseLeave={() => setIndexHover(null)}
+        className={cn(
+          "transition-all",
+          (indexHover == null || indexHover === idx) &&
+            COLORS[firstOccurrences[tokens[0]!.id]! % COLORS.length],
+          props.isFetching && "opacity-50"
+        )}
       >
-        {props.data && tokenCount > 0 && (
-          <span
-            className={cn(
-              "transition-opacity",
-              props.isFetching && "opacity-50"
-            )}
-          >
-            [
-            {props.data.map((segment, segmentIdx) => (
-              <Fragment key={segmentIdx}>
-                {segment.tokens.map((token) => (
-                  <Fragment key={token.idx}>
-                    <span
-                      onMouseEnter={() => setIndexHover(segmentIdx)}
-                      onMouseLeave={() => setIndexHover(null)}
-                      className={cn(
-                        "transition-colors",
-                        indexHover === segmentIdx &&
-                          COLORS[segmentIdx % COLORS.length]
-                      )}
-                    >
-                      {token.id}
-                    </span>
-                    <span className="last-of-type:hidden">{", "}</span>
-                  </Fragment>
-                ))}
+        {showWhitespace || indexHover === idx
+          ? encodeWhitespace(text)
+          : text}
+      </span>
+    ))}
+  </pre>
+
+  <pre
+    className={
+      "min-h-[256px] max-w-[100vw] overflow-auto whitespace-pre-wrap break-all rounded-md border bg-slate-50 p-4 shadow-sm"
+    }
+  >
+    {props.data && tokenCount > 0 && (
+      <span
+        className={cn(
+          "transition-opacity",
+          props.isFetching && "opacity-50"
+        )}
+      >
+        [
+        {props.data.map(({ tokens }, segmentIdx) => (
+          <Fragment key={segmentIdx}>
+            {tokens.map(({ id, idx }) => (
+              <Fragment key={idx}>
+                <span
+                  onMouseEnter={() => setIndexHover(segmentIdx)}
+                  onMouseLeave={() => setIndexHover(null)}
+                  className={cn(
+                    "transition-colors",
+                    indexHover === segmentIdx &&
+                      COLORS[firstOccurrences[id]! % COLORS.length]
+                  )}
+                >
+                  {id}
+                </span>
+                <span className="last-of-type:hidden">{", "}</span>
               </Fragment>
             ))}
-            ]
-          </span>
-        )}
-      </pre>
+          </Fragment>
+        ))}
+        ]
+      </span>
+    )}
+  </pre>
 
-      <div className="flex items-center space-x-2">
-        <Checkbox
-          id="terms"
-          checked={showWhitespace}
-          onClick={() => setShowWhitespace((v) => !v)}
-        />
-        <label
-          htmlFor="terms"
-          className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-        >
-          Show whitespace
-        </label>
-      </div>
-    </>
-  );
+  <div className="flex items-center space-x-2">
+    <Checkbox
+      id="terms"
+      checked={showWhitespace}
+      onClick={() => setShowWhitespace((v) => !v)}
+    />
+    <label
+      htmlFor="terms"
+      className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+    >
+      Show whitespace
+    </label>
+  </div>
+</>
+);
 }

--- a/src/sections/TokenViewer.tsx
+++ b/src/sections/TokenViewer.tsx
@@ -48,6 +48,8 @@ function encodeWhitespace(str: string) {
   return result;
 }
 
+const firstOccurrences: Record<number, number> = {};
+
 export function TokenViewer(props: {
   isFetching: boolean;
   model: string | undefined;
@@ -64,10 +66,10 @@ export function TokenViewer(props: {
   const [showWhitespace, setShowWhitespace] = useState(false);
 
   // Keep track of the first occurrence of each token
-  const firstOccurrences: Record<number, number> = {};
   props.data?.forEach(({ tokens }) => {
     tokens.forEach(({ id, idx }) => {
       if (firstOccurrences[id] == null) {
+        console.log("firstOccurrences", id, idx);
         firstOccurrences[id] = idx;
       }
     });

--- a/src/sections/TokenViewer.tsx
+++ b/src/sections/TokenViewer.tsx
@@ -91,7 +91,7 @@ export function TokenViewer(props: {
     )}
   </div>
 
-  <pre className="min-h-[256px] max-w-[100vw] overflow-auto whitespace-pre-wrap break-all rounded-md border bg-slate-50 p-4 shadow-sm">
+  <pre className="min-h-[256px] max-w-[100vw] overflow-auto whitespace-pre-wrap break-word rounded-md border bg-slate-50 p-4 shadow-sm">
     {props.data?.map(({ text, tokens }, idx) => (
       <span
         key={idx}
@@ -113,7 +113,7 @@ export function TokenViewer(props: {
 
   <pre
     className={
-      "min-h-[256px] max-w-[100vw] overflow-auto whitespace-pre-wrap break-all rounded-md border bg-slate-50 p-4 shadow-sm"
+      "min-h-[256px] max-w-[100vw] overflow-auto whitespace-pre-wrap break-word rounded-md border bg-slate-50 p-4 shadow-sm"
     }
   >
     {props.data && tokenCount > 0 && (

--- a/src/sections/TokenViewer.tsx
+++ b/src/sections/TokenViewer.tsx
@@ -73,8 +73,6 @@ export function TokenViewer(props: {
     });
   });
 
-  console.log(props.data)
-
   return (
     <>
       <div className="flex gap-4">


### PR DESCRIPTION
This PR assigns token colour by ID rather than by position. This makes highlighting more consistent.

Before:

<img width="423" alt="Screenshot 2023-04-24 at 11 43 48 am" src="https://user-images.githubusercontent.com/57783927/233895422-4b1642a9-13fa-4c0b-afdc-2478f7a0e02a.png">

(Note that the second "kindness" has a different colour from the first "kindness".)

After:

<img width="423" alt="Screenshot 2023-04-24 at 11 43 31 am" src="https://user-images.githubusercontent.com/57783927/233895392-1253d7fd-9efe-4e43-a644-f1e72eeee05b.png">

This colour assignment persists for the duration of the session (until the user closes or refreshes the page). The benefit of this is that a change to the beginning of the text doesn't throw off the colours in subsequent parts. The tradeoff is that token colours may change between sessions, which might seem confusing to users. But I think the more immediate in-session consistency is worth the loss of between-session consistency.

I also changed the break behaviour from `break-all` to `break-word` to stop confusing breaking of words/numbers across lines.