### PR TITLE
Add DeepSeek-V4 family

### DIFF
--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -75,6 +75,7 @@ export const openSourceModels = z.enum([
   "microsoft/phi-2",
   "google/gemma-7b",
   "deepseek-ai/DeepSeek-R1",
+  "deepseek-ai/DeepSeek-V4-Pro",
   "Qwen/Qwen2.5-72B",
   // "mistralai/Mistral-7B-v0.1",
   "tiiuae/falcon-7b",


### PR DESCRIPTION
Deepseek V4 uses a different tokenizer than the existing R1. It might be worth listing.